### PR TITLE
add running test part into .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: node_js
 node_js:
   - '9'
-  - '8'
-  - '7'
-  - '6'
+  - '8' 
+
+install:
+  - npm install
+  - npm install --only=dev
+
+script:
+  - npm run test


### PR DESCRIPTION
Just a quick look of the repo and make minor changes in my spare time before go to bed.
However, I temporarily removed the `nodejs` v6 and v7.
It seems that this two versions can't pass the test at this time point. As shown in my test build:
https://travis-ci.org/hsiaoyi0504/newsroom/builds/305664626