### PR TITLE
assign object to module.exports

### DIFF
--- a/src/questions/index.js
+++ b/src/questions/index.js
@@ -1,2 +1,4 @@
-module.exports.getSourceQuestion = require('./getSourceQuestion');
-module.exports.getTitleQuestion = require('./getTitleQuestion');
+module.exports = {
+  getSourceQuestion: require('./getSourceQuestion'),
+  getTitleQuestion: require('./getTitleQuestion'),
+};


### PR DESCRIPTION
`module.exports = exports`

We usually use one of them:

```js
module.exports = {
  getSourceQuestion: require('./getSourceQuestion'),
  getTitleQuestion: require('./getTitleQuestion'),
};
```

Or

```js
exports.getSourceQuestion = require('./getSourceQuestion');
exports.getTitleQuestion = require('./getTitleQuestion');
```